### PR TITLE
Fix gesture and some delegate calls

### DIFF
--- a/Classes/ITRAirSideMenu.h
+++ b/Classes/ITRAirSideMenu.h
@@ -11,6 +11,7 @@
 
 @property (weak, readwrite, nonatomic) id<ITRAirSideMenuDelegate> delegate;
 
+@property (assign, readonly, nonatomic) BOOL leftMenuVisible;
 @property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;
 @property (strong, readwrite, nonatomic) UIImage *backgroundImage;
 @property (assign, readwrite, nonatomic) BOOL panGestureEnabled;

--- a/Classes/ITRAirSideMenu.m
+++ b/Classes/ITRAirSideMenu.m
@@ -206,10 +206,7 @@
     CATransform3D menuTranslateTransform = _menuViewContainer.layer.transform;
     menuTranslateTransform = CATransform3DTranslate(menuTranslateTransform, -_menuViewTranslateX, 0, 0);
     _menuViewContainer.layer.transform = menuTranslateTransform;
-    
-    if ([self.delegate conformsToProtocol:@protocol(ITRAirSideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:willShowMenuViewController:)]) {
-        [self.delegate sideMenu:self willShowMenuViewController:menuViewController];
-    }
+
 }
 
 - (void)showLeftMenuViewController
@@ -217,7 +214,13 @@
     if (!self.leftMenuViewController) {
         return;
     }
-    
+
+    if ([self.delegate conformsToProtocol:@protocol(ITRAirSideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:willShowMenuViewController:)]) {
+        [self.delegate sideMenu:self willShowMenuViewController:self.leftMenuViewController];
+    }
+
+    self.leftMenuVisible = YES;
+
     [self.leftMenuViewController beginAppearanceTransition:YES animated:YES];
     self.leftMenuViewController.view.hidden = NO;
     [self.view.window endEditing:YES];
@@ -264,7 +267,11 @@
 
         _menuViewContainer.layer.transform = CATransform3DIdentity;
         
-    } completion:nil];
+    } completion:^(BOOL finished) {
+        if ([self.delegate respondsToSelector:@selector(sideMenu:didShowMenuViewController:)]) {
+            [self.delegate sideMenu:self didShowMenuViewController:self.leftMenuViewController];
+        }
+    }];
     
 }
 
@@ -396,6 +403,14 @@
 - (BOOL)gestureRecognizerShouldBegin:(UIPanGestureRecognizer *)gestureRecognizer
 {
     CGPoint translation = [gestureRecognizer translationInView:self.view];
+
+    if (self.leftMenuVisible) {
+        if (translation.x > 0) {
+            return NO;
+        }
+    } else if (translation.x <= 0) {
+        return NO;
+    }
 
     return fabs(translation.y) < fabs(translation.x);
 }
@@ -624,7 +639,5 @@
     
     return YES;
 }
-
-
 
 @end


### PR DESCRIPTION
This PR incorporates all the changes that I proposed before.

As I left it in the other PR the gesture recognizer is still recognizing swipes in the wrong direction, i.e., right-to-left swipes will trigger a menu open if it's currently closed. Fixed that as well.

Also, some delegate calls are not triggered at all. So far I only implemented the ones that I currently need, but the same logic applies elsewhere.

Finally, the leftMenuVisible property wasn't being updated _at all_. Fixed that too.
