### PR TITLE
Fix "squishy" animation and close-menu threshold

### DIFF
--- a/Classes/ITRAirSideMenu.m
+++ b/Classes/ITRAirSideMenu.m
@@ -230,7 +230,7 @@
     [self setAnchorPoint:CGPointMake(1.0, 0.5) forView:_contentViewContainer];
     [self setAnchorPoint:CGPointMake(1.0, 0.5) forView:_contentViewController.view];
     
-    [UIView animateWithDuration:self.animationDuration animations:^{
+    [UIView animateWithDuration:self.animationDuration delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
         
         //content view scale transform
         CATransform3D contentScaleTransform =  _contentViewContainer.layer.transform;
@@ -356,7 +356,7 @@
     
     if (animated) {
         [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
-        [UIView animateWithDuration:self.animationDuration animations:^{
+        [UIView animateWithDuration:self.animationDuration delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
             animationBlock();
         } completion:^(BOOL finished) {
             [[UIApplication sharedApplication] endIgnoringInteractionEvents];
@@ -478,53 +478,50 @@
             CGFloat contentViewScale = 1 + (_contentViewScaleValue - 1)* (newLocationPoint.x / 300);
             CGFloat angle = (newLocationPoint.x - _lastPoint.x) * _contentViewRotatingAngle/300;
             CGFloat tranformX = newLocationPoint.x * _contentViewTranslateX/300;
-            
-            [UIView animateWithDuration:self.animationDuration animations:^{
-                
-                _totalAngle = _totalAngle + angle;
-                
-                //content view scale transform
-                CATransform3D contentScaleTransform =  _contentViewContainer.layer.transform;
-                contentScaleTransform = CATransform3DMakeScale(contentViewScale, contentViewScale,1.0f);
-                _contentViewContainer.layer.transform = contentScaleTransform;
 
-                if (angle != 0) {
-                    //content view rotate transform
-                    CATransform3D contentRotateTransform =  _contentViewController.view.layer.transform;
-                    contentRotateTransform = CATransform3DMakeRotation(_totalAngle * M_PI/180.0f, 0.0f, -1.0f, 0.0f);
-                    CATransform3D sublayerTransform = _contentViewController.view.superview.layer.sublayerTransform;
-                    sublayerTransform.m34 = 1.0f / -300.0f;
-                    _contentViewController.view.superview.layer.sublayerTransform = sublayerTransform;
-                    _contentViewController.view.layer.transform = contentRotateTransform;
-                }
+            _totalAngle = _totalAngle + angle;
 
-                //content view translate transform
-                CATransform3D contentTranslateTransform = _contentViewContainer.layer.transform;
-                contentTranslateTransform = CATransform3DTranslate(contentTranslateTransform, tranformX, 0, 0);
-                _contentViewContainer.layer.transform = contentTranslateTransform;
-                
-                
-                //calculation of scale, angle & translate for menu view based on pan position
-                if (angle != 0) {
-                    CGFloat menuAngle = _menuViewRotatingAngle - (newLocationPoint.x) * _menuViewRotatingAngle/300;
+            //content view scale transform
+            CATransform3D contentScaleTransform =  _contentViewContainer.layer.transform;
+            contentScaleTransform = CATransform3DMakeScale(contentViewScale, contentViewScale,1.0f);
+            _contentViewContainer.layer.transform = contentScaleTransform;
 
-                    //menu view rotate transform
-                    CATransform3D menuRotateTransform =  _leftMenuViewController.view.layer.transform;
-                    menuRotateTransform = CATransform3DMakeRotation(menuAngle * M_PI/180.0f, 0.0f, -1.0f, 0.0f);
-                    CATransform3D sublayerTransform1 = _leftMenuViewController.view.superview.layer.sublayerTransform;
-                    sublayerTransform1.m34 = 1.0f / -300.0f;
-                    _leftMenuViewController.view.superview.layer.sublayerTransform = sublayerTransform1;
-                    _leftMenuViewController.view.layer.transform = menuRotateTransform;
-                }
+            if (angle != 0) {
+                //content view rotate transform
+                CATransform3D contentRotateTransform =  _contentViewController.view.layer.transform;
+                contentRotateTransform = CATransform3DMakeRotation(_totalAngle * M_PI/180.0f, 0.0f, -1.0f, 0.0f);
+                CATransform3D sublayerTransform = _contentViewController.view.superview.layer.sublayerTransform;
+                sublayerTransform.m34 = 1.0f / -300.0f;
+                _contentViewController.view.superview.layer.sublayerTransform = sublayerTransform;
+                _contentViewController.view.layer.transform = contentRotateTransform;
+            }
 
-                CGFloat menuTransformValue = (_menuViewTranslateX * newLocationPoint.x/300) - _menuViewTranslateX - _menuViewContainer.frame.origin.x;
+            //content view translate transform
+            CATransform3D contentTranslateTransform = _contentViewContainer.layer.transform;
+            contentTranslateTransform = CATransform3DTranslate(contentTranslateTransform, tranformX, 0, 0);
+            _contentViewContainer.layer.transform = contentTranslateTransform;
 
-                //menu view translate transform
-                CATransform3D menuTranslateTransform = _menuViewContainer.layer.transform;
-                menuTranslateTransform = CATransform3DTranslate(menuTranslateTransform, menuTransformValue, 0, 0);
-                _menuViewContainer.layer.transform = menuTranslateTransform;
-                
-            } completion:nil];
+
+            //calculation of scale, angle & translate for menu view based on pan position
+            if (angle != 0) {
+                CGFloat menuAngle = _menuViewRotatingAngle - (newLocationPoint.x) * _menuViewRotatingAngle/300;
+
+                //menu view rotate transform
+                CATransform3D menuRotateTransform =  _leftMenuViewController.view.layer.transform;
+                menuRotateTransform = CATransform3DMakeRotation(menuAngle * M_PI/180.0f, 0.0f, -1.0f, 0.0f);
+                CATransform3D sublayerTransform1 = _leftMenuViewController.view.superview.layer.sublayerTransform;
+                sublayerTransform1.m34 = 1.0f / -300.0f;
+                _leftMenuViewController.view.superview.layer.sublayerTransform = sublayerTransform1;
+                _leftMenuViewController.view.layer.transform = menuRotateTransform;
+            }
+
+            CGFloat menuTransformValue = (_menuViewTranslateX * newLocationPoint.x/300) - _menuViewTranslateX - _menuViewContainer.frame.origin.x;
+
+            //menu view translate transform
+            CATransform3D menuTranslateTransform = _menuViewContainer.layer.transform;
+            menuTranslateTransform = CATransform3DTranslate(menuTranslateTransform, menuTransformValue, 0, 0);
+            _menuViewContainer.layer.transform = menuTranslateTransform;
+
             _lastPoint.x = newLocationPoint.x;
         }
         
@@ -557,11 +554,13 @@
                 if (self.contentViewContainer.frame.origin.x < 0) {
                     [self hideMenuViewController];
                 } else {
-                    if (self.leftMenuViewController) {
+                    if (self.isLeftMenuVisible && (300 - _lastPoint.x) > self.panMinimumOpenThreshold) {
+                        [self hideMenuViewController];
+                    }
+                    else if (self.leftMenuViewController) {
                         [self showLeftMenuViewController];
                     }
                 }
-            
         }
     }
     


### PR DESCRIPTION
Closing the menu via gesture wouldn't happen until you cross the threshold on the _left_ edge, which is probably not intended and mostly counter-intuitive. Fixed it to account for a right-to-left pan larger than the opening threshold.

Regarding the animation, having an animation block on the "changed" state of the gesture recognizer makes the panel drag feel somewhat squishy. Since the "end" state calls an animation block to finish the operation, it's just fine to perform the changes without animation. Unfortunately things still don't feel natural because of the time-warp effect due to the content container scaling.

Also, it seems to compound with the hardcoded 300 that's found sprinkled all over the code. (I believe it would be better to use abstract coordinates in the 0.0-1.0 range and scale that with the screen width, but I'm still unsure about that). There's probably some math involving the scale factor in play.

Talking about the scaling, according to the design of the app I had a target translation of 225 points when the menu is open or a proportional translation for screen widths larger than 320 points. In order to achieve that, when configuring the component I had to use code like this:

```
// Scale factor to apply to the content view, i.e., height equals
// to 380 points if the screen is 568 points tall.
CGFloat scale = 380.0/568.0;
_menuController.contentViewScaleValue = scale;

// If the screen is 320 points wide, I want the scaled and translated view to
// end at x = 225 points. Else, keep this proportion.
CGFloat width = CGRectGetWidth(self.window.bounds);
CGFloat expectedTranslation = 225.0/320.0 * width;

// Horizontal scaling has itself a translation effect
// because of the anchor change...
CGFloat translationFromScale = width - (scale * width);

// Compensate for that, noticing that the translation
// is also affected by the scale
CGFloat remainingTranslation = (CGFloat)ceil((expectedTranslation - translationFromScale) / scale);

_menuController.contentViewTranslateX = remainingTranslation;
```

This works for contentViewRotatingAngle = 0, and I haven't tested what is the effect for rotated content.

Perhaps it would be a better idea to have this as the default behavior, else the ...TranslateX properties name and purpose end up being a bit misleading.

On a last note, it could be better to follow UITableView's delegation pattern and optionally ask the delegate for the translation and scaling values, since they should probably adapt to screen orientation changes. One could conceivably listen to orientation changes and modify the properties directly, but this feels a little like an antipattern.
